### PR TITLE
Fix disappearing variables

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -72,14 +72,6 @@ class Blocks extends React.Component {
         );
         this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
-        // we actually never want the workspace to enable "refresh toolbox" - this basically re-renders the
-        // entire toolbox every time we reset the workspace.  We call updateToolbox as a part of
-        // componentDidUpdate so the toolbox will still correctly be updated
-        this.setToolboxRefreshEnabled = this.workspace.setToolboxRefreshEnabled.bind(this.workspace);
-        this.workspace.setToolboxRefreshEnabled = () => {
-            this.setToolboxRefreshEnabled(false);
-        };
-
         // @todo change this when blockly supports UI events
         addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
         addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
@@ -136,8 +128,6 @@ class Blocks extends React.Component {
         if (this.props.isVisible) { // Scripts tab
             this.workspace.setVisible(true);
             this.props.vm.refreshWorkspace();
-            // Re-enable toolbox refreshes without causing one. See #updateToolbox for more info.
-            this.workspace.toolboxRefreshEnabled_ = true;
             window.dispatchEvent(new Event('resize'));
         } else {
             this.workspace.setVisible(false);
@@ -155,10 +145,6 @@ class Blocks extends React.Component {
         const categoryId = this.workspace.toolbox_.getSelectedCategoryId();
         const offset = this.workspace.toolbox_.getCategoryScrollOffset();
         this.workspace.updateToolbox(this.props.toolboxXML);
-        // In order to catch any changes that mutate the toolbox during "normal runtime"
-        // (variable changes/etc), re-enable toolbox refresh.
-        // Using the setter function will rerender the entire toolbox which we just rendered.
-        this.workspace.toolboxRefreshEnabled_ = true;
 
         const currentCategoryPos = this.workspace.toolbox_.getCategoryPositionById(categoryId);
         const currentCategoryLen = this.workspace.toolbox_.getCategoryLengthById(categoryId);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -319,7 +319,7 @@ class Blocks extends React.Component {
         this.blocks = blocks;
     }
     handlePromptStart(message, defaultValue, callback, optTitle, optVarType) {
-        const p = { prompt: { callback, message, defaultValue } };
+        const p = { prompt: { callback, message, defaultValue, showMoreOptions: false } };
         p.prompt.title = optTitle ? optTitle :
             this.ScratchBlocks.Msg.VARIABLE_MODAL_TITLE;
         p.prompt.varType = typeof optVarType === 'string' ?


### PR DESCRIPTION
**Bug Report:** 

> Wir haben den spannenden Bug, dass 'manchmal' wenn ich eine Variable anlege, die zwar im Hintergrund angelegt wird, aber nicht im Frontent unter Variablen zu sehen ist. Lege ich die variable mit demselben Namen an, kommt eine Warnung, dass die Variable schon existiert. Speichere ich das Spiel ab und öffne es wieder, sehe ich die Variable. Ich hatte mal die Vermutung, dass es im Zusammenhang mit 'Bühne vergößern' steht, heute morgen hatten wir den Bug aber auch ohne vorher vergrößerte Bühne. Das ist relevant, weil man ohne die Variable in den Lernspielen ab Mathefant nicht weiterkommt.

I managed to track the problem down to the `blocks.jsx`, where the toolbox refresh was disabled and toolbox refreshes would only be executed manually. Removing that code fixes the bug!

I'm not sure how bad the performance impact of this even is? In the comment it says the toolbox "rerenders […] every time we reset the workspace." How often do we do that?