### PR TITLE
Fix a few texts

### DIFF
--- a/src/components/mobile-screen/mobile-screen.css
+++ b/src/components/mobile-screen/mobile-screen.css
@@ -104,6 +104,10 @@
     z-index: 10;
 }
 
+.block3 {
+    width: 85vw;
+}
+
 .fant {
     position: absolute;
     width: 35vw;

--- a/src/components/mobile-screen/mobile-screen.jsx
+++ b/src/components/mobile-screen/mobile-screen.jsx
@@ -106,18 +106,10 @@ const MobileScreenComponent = () => (
                     role="Lerkräfte-Blog"
                     alt="Link zur Lehrkräfte-Seite"
                     title="Link zur Lehrkräfte-Seite"
-                    className={styles.block1}
+                    className={styles.block3}
                     draggable={false}
                     src={block3} />
             </Link>
-
-            <div className={classNames(styles.innerWrapper, styles.thirdWrapper)}>
-                <p>
-                    Auf der re:publica kann Programmieren mit der Maus von Groß UND Klein <span className={styles.boldOrange}>#mausprobiert </span>
-                    werden. Spielerisch mit Code Bilder mit der Maus, der Ente und dem Elefanten
-                    erzeugen, das Ergebnis dann teilen oder einfach direkt als Button ausdrucken.
-                </p>
-            </div>
         </div>
         <InlineSVG className={styles.mausQuestion} svg={mausQuestion} />
         <Link className={styles.link} href="/inhalte/impressum">Impressum</Link>

--- a/src/lib/content/parents.md
+++ b/src/lib/content/parents.md
@@ -66,12 +66,6 @@ Mobile Safari (11+)
 - Zielgruppe sind Kinder ab 8 Jahre. (Die Kinder sollten kurze Texte lesen können. Jüngere Kinder können die Anwendung mit ihren Eltern nutzen.)
 - Zielausspielung sind Tablets (ab iOS 11) und Desktop-Geräte, auf Smartphones ist die Anwendung derzeit leider nicht nutzbar.
 
-## Umsetzung
-
-- Vorbild und Grundlage ist die grafische Programmiersprache **Scratch des MIT Lifelong Kindergarten** (Flash basiert)
-- Das MIT entwickelt Version 3 dieser grafischen Programmiersprache. Die neue Anwendung ermöglicht es, Scratch auch auf Tablets zu benutzen. Die Ausspielung für Smartphones ist derzeit nicht Teil des Projektes. Eine Vorschau davon ist hier zu finden: https://beta.scratch.mit.edu
-- Scratch ist Open Source Software. Deshalb konnten wir eine WDR-Version von Scratch 3 erstellen und sie in den Punkten Design, Figuren und Sounds der Sendung mit der Maus anpassen.
-
 ## Vision
 
 Wir erhoffen uns durch **Programmieren mit der Maus** mehr Kinder spielerisch für das Thema zu begeistern. Dabei ist vor allem wichtig, die selbstbestimmte Mediennutzung zu fördern: Selbermachen statt konsumieren.


### PR DESCRIPTION
The feedback was:

- In der mobilen Ansicht kann der Hinweis auf die re:publica (letzter weißer Block vor der Maus) weg
- In der Eltern-Ansicht ist der Abschnitt 'Umsetzung' veraltet und kann auch raus https://programmieren.wdrmaus.de/eltern

So I did that!