### PR TITLE
Make welcome screen more welcoming

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -9,7 +9,10 @@
     padding: .5rem 1.5rem;
     position: relative;
     border: none;
+    box-shadow: 2px 2px 6px -3px rgba(0, 0, 0, .7);
     color: white;
+    font-weight: bold;
+    font-family: inherit;
     font-size: inherit;
 }
 

--- a/src/components/menu-listing/menu-listing.css
+++ b/src/components/menu-listing/menu-listing.css
@@ -8,7 +8,7 @@
     padding: 1rem;
     border: 1px solid rgb(216, 215, 215);
     border-radius: 1rem;
-    box-shadow: .125rem .125rem .75rem 0 rgba(0, 0, 0, 0.5);
+    box-shadow: 2px 2px 12px -4px rgba(0, 0, 0, .7);
     min-width: 14rem;
     max-width: 14rem;
     max-height: 16rem;

--- a/src/components/welcome-screen/welcome-screen.css
+++ b/src/components/welcome-screen/welcome-screen.css
@@ -1,26 +1,80 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    background: url(../gui/bg_header@1x.png);
+    padding: 2rem;
+}
+
 .wrapper {
     margin-top: 2.5rem;
-    max-width: 40rem;
+    max-width: 700px;
+    font-size: 1.4rem;
 }
 
 .wrapper p {
-    font-size: 1.4rem;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    font-size: inherit;
+}
+
+.section {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+    border-bottom: 1px solid #ddd;
+    color: inherit;
+    text-decoration: none;
+}
+
+.section:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: 0;
+}
+
+.section-text {
+    padding-right: 1em;
+}
+
+.section-small-text {
+    margin-top: 0.25em;
+    margin-bottom: 0.75em;
+    font-size: 0.7em;
+    line-height: 1.5;
+}
+
+.wdr-logo {
+    align-self: flex-start;
+    height: 2rem;
+}
+
+.logo {
+    display: block;
+    width: 100%;
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2rem;
+}
+
+.image-hello-world {
+    display: block;
+    max-width: 150px;
+    margin-right: 2rem;
+}
+
+.image-maus {
+    display: block;
+    max-width: 90px;
+    margin-right: 4rem;
 }
 
 .inner-wrapper {
-    padding: 2rem;
+    padding: 3rem;
     background-color: white;
-    box-shadow: 0 0 0.8rem 1px rgba(0,0,0,.5);
-}
-
-.button-wrapper {
-    display: flex;
-    justify-content: space-around;
-    margin: 2rem 0;
-}
-
-.button {
-    font-size: 1.4rem;
-    width: 16rem;
-    justify-content: center;
+    box-shadow: 2px 2px 12px -4px rgba(0, 0, 0, .7);
 }

--- a/src/components/welcome-screen/welcome-screen.jsx
+++ b/src/components/welcome-screen/welcome-screen.jsx
@@ -1,37 +1,79 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { Link } from 'redux-little-router';
 
-import LogoOverlay from '../logo-overlay/logo-overlay.jsx';
 import Button from '../button/button.jsx';
-
 import styles from './welcome-screen.css';
 
+import { eduUrl } from '../../lib/routing';
+
+import wdrLogo from '../../../assets/img/wdr_logo.svg';
+import logo from '../../../assets/img/head_logo.png';
+import helloWorldImage from '../../lib/edu/shared_assets/L00.jpg';
+import mausImage from '../../../assets/img/maus1.png';
+
 const WelcomeScreenComponent = (props) => (
-    <LogoOverlay>
+    <div className={styles.container}>
+        <img
+            alt="WDR"
+            className={styles.wdrLogo}
+            draggable={false}
+            src={wdrLogo}
+        />
+
         <div className={styles.wrapper}>
             <div className={styles.innerWrapper}>
-                <p>Willkommen zu <strong>Programmieren mit der Maus</strong></p>
+                <img className={styles.logo} src={logo} />
+
+                <p>Willkommen zu <strong>Programmieren mit der Maus</strong>!</p>
                 <p>
-                Hier lernst du Schritt für Schritt Bildergeschichten 
-                und Spiele mit der Maus zu programmieren.
-                Viel Spaß!
+                    Hier lernst du Schritt für Schritt Bildergeschichten und Spiele mit der Maus zu programmieren. Viel Spaß!
                 </p>
-                <p className={styles.buttonWrapper}>
-                    <Button style='primary' onClick={props.onIntroClick}>
-                        Lernen, wie es geht
-                    </Button>
-                    <Button style='primary' onClick={props.onMenuClick}>
-                        Zur Übersicht
-                    </Button>
-                </p>
+
+                <Link href={eduUrl('00')} className={styles.section}>
+                    <div className={styles.sectionText}>
+                        Spielst du zum ersten Mal?
+
+                        <div className={styles.sectionSmallText}>
+                            Fang am besten mit unserem ersten Lernspiel an.
+                        </div>
+
+                        <Button style="primary">
+                            <div style={{ whiteSpace: 'nowrap' }}>
+                                Lernen, wie es geht ‣
+                            </div>
+                        </Button>
+                    </div>
+
+                    <img
+                        src={helloWorldImage}
+                        alt=""
+                        className={styles.imageHelloWorld}
+                    />
+                </Link>
+
+                <Link href="/" className={styles.section}>
+                    <div className={styles.sectionText}>
+                        Kennst du dich schon aus?
+
+                        <div className={styles.sectionSmallText}>
+                            Gehe direkt zur Übersicht und klicke dein nächstes Lernspiel an. Gespeicherte Spiele findest du unter „Meine Sachen“.
+                        </div>
+                        <Button style="primary">
+                            <div style={{ whiteSpace: 'nowrap' }}>
+                                Alle Lernspiele ‣
+                            </div>
+                        </Button>
+                    </div>
+
+                    <img
+                        src={mausImage}
+                        alt=""
+                        className={styles.imageMaus}
+                    />
+                </Link>
             </div>
         </div>
-    </LogoOverlay>
+    </div>
 );
-
-WelcomeScreenComponent.propTypes = {
-    onIntroClick: PropTypes.func.isRequired,
-    onMenuClick: PropTypes.func.isRequired,
-};
 
 export default WelcomeScreenComponent;

--- a/src/containers/app.jsx
+++ b/src/containers/app.jsx
@@ -148,8 +148,11 @@ class App extends Component {
             return;
         }
 
-        this.props.redirectWelcome();
         localStorage.setItem(lsKeyVisited, 'yes');
+
+        if (this.props.isHomepage) {
+            this.props.redirectWelcome();
+        }
     }
 
     renderView() {
@@ -187,6 +190,7 @@ class App extends Component {
 }
 
 App.propTypes = {
+    isHomepage: PropTypes.bool.isRequired,
     view: PropTypes.string.isRequired,
     setUserId: PropTypes.func.isRequired,
     userId: PropTypes.string,
@@ -204,6 +208,7 @@ const ConnectedApp = connect(
     (state) => {
         const result = state.router.result || {};
         return {
+            isHomepage: state.router.route === '/',
             view: result.view || '',
             userId: state.scratchGui.project.userId,
             offlineEnabled: state.scratchGui.offline.enabled,

--- a/src/containers/welcome-screen.jsx
+++ b/src/containers/welcome-screen.jsx
@@ -1,30 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { push } from 'redux-little-router';
 
-import { eduUrl } from '../lib/routing';
 import WelcomeScreenComponent from '../components/welcome-screen/welcome-screen.jsx';
 
 class WelcomeScreen extends React.Component {
     render() {
-        return (
-            <WelcomeScreenComponent
-                onIntroClick={this.props.handleIntroClick}
-                onMenuClick={this.props.handleMenuClick}
-            />
-        );
+        return <WelcomeScreenComponent />;
     }
 }
 
-WelcomeScreen.propTypes = {
-    handleIntroClick: PropTypes.func.isRequired,
-    handleMenuClick: PropTypes.func.isRequired,
-};
-
-const mapDispatchToProps = (dispatch) => ({
-    handleIntroClick: () => dispatch(push(eduUrl('00'))),
-    handleMenuClick: () => dispatch(push('/')),
-});
-
-export default connect(() => ({}), mapDispatchToProps)(WelcomeScreen);
+export default WelcomeScreen;


### PR DESCRIPTION
**Motivation**: We noticed that a large number of people leave the page directly on the welcome screen. (This may be partly related to a caching issue on CloudFront that we discovered at the same time. But it was a good idea to improve the welcome page, so we went ahead with that.)

One theory was that the welcome screen doesn't guide the users to what they should do next. (I personally think that the screen looked a bit like an error page, with it's small white box with two red-ish buttons.)

We redesigned the page to be a bit more friendly, with a few cute Maus illustrations, more text to explain what the two buttons are for, and a bit more whitespace.

**Side Note**: In the previous version, there was a bug where the buttons could be not visible (and you couldn't scroll them into view!). This has also been fixed!

**Another thing** that we improved: We will no longer redirect users to the welcome screen if they directly request a Lernspiel (or any URL that is not the homepage). The assumption is that users that click on a link from Penny's video series want to go directly to the Lernspiel.

**One last thing:** I finally set the button font-family to `inherit`, so we can get all of that Titillium goodness!

Before:

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/2098462/78259861-85e2c280-74fd-11ea-8f44-277045fab1ea.png">

After:

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/2098462/78259983-b32f7080-74fd-11ea-8918-488840420ca3.png">
