### PR TITLE
piano analytics - added missing events

### DIFF
--- a/src/components/edu-stage/edu-stage.jsx
+++ b/src/components/edu-stage/edu-stage.jsx
@@ -17,6 +17,7 @@ import { eduUrl } from '../../lib/routing'
 import { gamesKeyed } from '../../lib/edu/'
 import VideoPlayer from '../video-player/video-player.jsx'
 import styles from './edu-stage.css'
+import { guiTypePages, paEvent } from '../../lib/piano-analytics/main'
 
 const EduStageComponent = (props) => {
   const [isPreVideoModalOpen, setPreVideoModalOpen] = useState(false)
@@ -58,7 +59,10 @@ const EduStageComponent = (props) => {
           <div className={styles.caption}>{props.caption}</div>
           <Button
             className={styles.fullscreenButton}
-            onClick={props.toggleFullscreen}
+            onClick={() => {
+              sendPaEvent(props.gameId, 'Fullscreen Button')
+              return props.toggleFullscreen()
+            }}
           >
             <img
               className={styles.fullscreenButtonIcon}
@@ -86,7 +90,10 @@ const EduStageComponent = (props) => {
             arrowLeft
             style="primary"
             disabled={props.slideIndex === 0}
-            onClick={props.previousSlide}
+            onClick={() => {
+              sendPaEvent(props.gameId, 'Zurück Button')
+              return props.previousSlide()
+            }}
           >
             Zurück
           </Button>
@@ -97,7 +104,10 @@ const EduStageComponent = (props) => {
             arrowRight
             style="primary"
             wiggle={props.slideIndex === 0 && !props.finished}
-            onClick={props.nextSlide}
+            onClick={() => {
+              sendPaEvent(props.gameId, 'Weiter Button')
+              return props.nextSlide()
+            }}
             disabled={props.finished}
           >
             {!props.linkNextGame ? 'Weiter' : 'Nächstes Lernspiel'}
@@ -106,6 +116,12 @@ const EduStageComponent = (props) => {
       </div>
     </>
   )
+}
+
+const sendPaEvent = (gameId, lastLevel) => {
+  const pages = guiTypePages(gameId)
+  pages.push(lastLevel)
+  paEvent.clickAction({ pages })
 }
 
 EduStageComponent.propTypes = {

--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -185,10 +185,12 @@ export const MenuComponent = (props) => {
           iconSvg={buttonIconMausseite}
           external
           linkTo="https://www.wdrmaus.de/"
-          onClick={() => {
-            // TODO: add click event
-            console.log("zur Maus-Seite")
-          }}
+          onClick={() =>
+            paEvent.clickExit({
+              pages: ['Menu', 'Zur Maus-Seite'],
+              pageType: 'Beitrag'
+            })
+          }
         >
           Zur Maus-Seite
         </MenuButton>

--- a/src/components/stage-header/stage-header.jsx
+++ b/src/components/stage-header/stage-header.jsx
@@ -7,6 +7,7 @@ import { Link } from 'redux-little-router'
 import Controls from '../../containers/controls.jsx'
 import Fullscreen from '../../containers/fullscreen.jsx'
 import MenuButton from '../menu-button/menu-button.jsx'
+import { guiTypePages, paEvent } from '../../lib/piano-analytics/main.js'
 
 import styles from './stage-header.css'
 import saveIcon from '!raw-loader!../../../assets/icons/header_save.svg'
@@ -14,7 +15,7 @@ import menuIcon from '!raw-loader!../../../assets/icons/header_menu.svg'
 import mailIcon from '!raw-loader!../../../assets/icons/menu_impressum.svg'
 
 const StageHeaderComponent = function (props) {
-  const { isFullScreen, onSaveProject, vm } = props
+  const { isFullScreen, onSaveProject, vm, gameId } = props
 
   return (
     <div
@@ -29,6 +30,8 @@ const StageHeaderComponent = function (props) {
           className={styles.controls}
           vm={vm}
           isFullScreen={isFullScreen}
+          onGreenFlagClick={() => sendPaEvent('clickAction', gameId, 'Los')}
+          onStopAllClick={() => sendPaEvent('clickAction', gameId, 'Stopp')}
         />
         {isFullScreen ? (
           <Fullscreen />
@@ -45,6 +48,7 @@ const StageHeaderComponent = function (props) {
                 iconSvg={mailIcon}
                 external
                 linkTo="mailto:maus@wdr.de"
+                onClick={() => sendPaEvent('clickExit', gameId, 'Feedback')}
               >
                 Feedback
               </MenuButton>
@@ -52,7 +56,10 @@ const StageHeaderComponent = function (props) {
                 orientation="vertical"
                 id="save"
                 iconSvg={saveIcon}
-                onClick={onSaveProject}
+                onClick={() => {
+                  sendPaEvent('clickAction', gameId, 'Speichern')
+                  return onSaveProject()
+                }}
               >
                 Speichern
               </MenuButton>
@@ -61,6 +68,7 @@ const StageHeaderComponent = function (props) {
                 linkTo="/"
                 className={styles.headerIcon}
                 iconSvg={menuIcon}
+                onClick={() => sendPaEvent('clickAction', gameId, 'Übersicht')}
               >
                 Übersicht
               </MenuButton>
@@ -72,9 +80,16 @@ const StageHeaderComponent = function (props) {
   )
 }
 
+const sendPaEvent = (eventType, gameId, lastLevel) => {
+  const pages = guiTypePages(gameId)
+  pages.push(lastLevel)
+  return paEvent[eventType]({ pages })
+}
+
 StageHeaderComponent.propTypes = {
   intl: intlShape,
   isFullScreen: PropTypes.bool.isRequired,
+  gameId: PropTypes.string,
   onSaveProject: PropTypes.func.isRequired,
   vm: PropTypes.instanceOf(VM).isRequired,
 }

--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -35,6 +35,10 @@ class Controls extends React.Component {
   }
   handleGreenFlagClick(e) {
     e.preventDefault()
+
+    if (this.props.onGreenFlagClick) {
+      this.props.onGreenFlagClick()
+    }
     if (e.shiftKey) {
       this.setState({ turbo: !this.state.turbo })
       this.props.vm.setTurboMode(!this.state.turbo)
@@ -44,6 +48,10 @@ class Controls extends React.Component {
   }
   handleStopAllClick(e) {
     e.preventDefault()
+
+    if (this.props.onStopAllClick) {
+      this.props.onStopAllClick()
+    }
     this.props.vm.stopAll()
   }
   render() {
@@ -65,6 +73,8 @@ class Controls extends React.Component {
 
 Controls.propTypes = {
   vm: PropTypes.instanceOf(VM),
+  onGreenFlagClick: PropTypes.func,
+  onStopAllClick: PropTypes.func
 }
 
 export default Controls

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -23,8 +23,7 @@ import { StageSizeProviderHOC } from '../lib/stage-size-provider.jsx'
 import GUIComponent from '../components/gui/gui.jsx'
 import { toggleLayoutMode } from '../reducers/layout-mode'
 import { setProjectUnchanged } from '../reducers/project-changed'
-import { paEvent } from '../lib/piano-analytics/main'
-import { menuTabTitles } from '../lib/piano-analytics/constants'
+import { guiTypePages, paEvent } from '../lib/piano-analytics/main'
 
 class GUI extends React.Component {
   constructor(props) {
@@ -157,11 +156,9 @@ const mapStateToProps = (state) => ({
 const logPageDisplay = (eduId, isNewProject, tab) => {
   let pages = []
   if (isNewProject) {
-    pages = [menuTabTitles[1], 'New Project']
-  } else if (eduId && eduId.match(/beispiel(0|0\d{1})?$/gm)) {
-    pages = [menuTabTitles[2], `Beispiel ${eduId}`]
+    pages = guiTypePages(null)
   } else if (eduId) {
-    pages = [menuTabTitles[0], `Lernspiel ${eduId}`]
+    pages = guiTypePages(eduId)
   }
 
   paEvent.pageDisplay({

--- a/src/containers/stage-header.jsx
+++ b/src/containers/stage-header.jsx
@@ -39,6 +39,7 @@ StageHeader.propTypes = {
 
 const mapStateToProps = (state) => ({
   isFullScreen: state.scratchGui.mode.isFullScreen,
+  gameId: state.scratchGui.eduLayer.gameId
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/lib/piano-analytics/main.js
+++ b/src/lib/piano-analytics/main.js
@@ -1,5 +1,10 @@
 import { pianoAnalytics } from 'piano-analytics-js'
-import { EVENTS, PROPERTIES, DEFAULT_PROPERTY_VALUES } from './constants'
+import {
+  EVENTS,
+  PROPERTIES,
+  DEFAULT_PROPERTY_VALUES,
+  menuTabTitles,
+} from './constants'
 
 pianoAnalytics.setConfigurations({
   site: 621455,
@@ -21,6 +26,18 @@ export const paSetConfig = () => {
     }
   }
   pianoAnalytics.setConfigurations(configurations)
+}
+
+export const guiTypePages = (gameId) => {
+  if (!gameId) {
+    return [menuTabTitles[1], 'New Project']
+  }
+
+  if (gameId.match(/beispiel(0|0\d{1})?$/gm)) {
+    return [menuTabTitles[2], `Beispiel ${gameId}`]
+  } else {
+    return [menuTabTitles[0], `Lernspiel ${gameId}`]
+  }
 }
 
 const pageLevelKeys = [
@@ -61,32 +78,27 @@ const getCustomProperties = (data) => {
   }
 }
 
-const clickEventEntries = () => {
-  const { pageDisplay, ...otherEvents } = EVENTS
+const pageValuesToData = ({ pages, pageType }) => {
+  let data = {}
 
-  return Object.entries(otherEvents).map(([eventName, eventKey]) => [
+  if (typeof pages === 'string') {
+    data[PROPERTIES.pageLevel1] = pages
+  } else {
+    const pagesList = [...pages].slice(0, 3)
+    pagesList.forEach((page, index) => {
+      data[PROPERTIES[`pageLevel${index + 1}`]] = page
+    })
+  }
+
+  if (pageType) data[PROPERTIES.siteType] = pageType
+  return data
+}
+
+const clickEventEntries = () => {
+  return Object.entries(EVENTS).map(([eventName, eventKey]) => [
     eventName,
-    (data) => sendEvent(eventKey, data),
+    (data) => sendEvent(eventKey, pageValuesToData(data)),
   ])
 }
 
-const clickEvents = Object.fromEntries(clickEventEntries())
-
-export const paEvent = {
-  pageDisplay: ({ pages, pageType }) => {
-    let data = {}
-
-    if (typeof pages === 'string') {
-      data[PROPERTIES.pageLevel1] = pages
-    } else {
-      const pagesList = [...pages].slice(0, 3)
-      pagesList.forEach((page, index) => {
-        data[PROPERTIES[`pageLevel${index + 1}`]] = page
-      })
-    }
-
-    if (pageType) data[PROPERTIES.siteType] = pageType
-    return sendEvent(EVENTS.pageDisplay, data)
-  },
-  ...clickEvents,
-}
+export const paEvent = Object.fromEntries(clickEventEntries())


### PR DESCRIPTION
### Proposed Changes

Previous PR: https://github.com/wdr-data/code4maus/pull/102
It adds more Piano Analytics' events to the App so that it can track the visitor's browsing behaviour.
New event types used like `click.action` and `click.exit`

### Reason for Changes

Want to get more insight about the user's behaviour in the app.

### Test Coverage

No tests were added.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

~Mac~ Linux
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
